### PR TITLE
Make active tab orange for vim-airline

### DIFF
--- a/autoload/airline/themes/apprentice.vim
+++ b/autoload/airline/themes/apprentice.vim
@@ -1,7 +1,7 @@
 let g:airline#themes#apprentice#palette = {}
 
-let s:N1   = [ '#bcbcbc', '#5f5f87', 250, 60 ]
-let s:N2   = [ '#1c1c1c', '#ff8700', 234, 65 ]
+let s:N1   = [ '#1c1c1c', '#ff8700', 234, 65 ]
+let s:N2   = [ '#bcbcbc', '#5f5f87', 250, 60 ]
 let s:N3   = [ '#262626', '#87875f', 235, 101 ]
 let g:airline#themes#apprentice#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
 


### PR DESCRIPTION
It looks like the way things are now the orange is defined once and affects both the tab bar and the statusline, so the change I make here also affects the statusline (in my opinion for the better though).  This should fix #7.

### Tabs ###
New (active is orange, client.coffee):
![screen shot 2015-06-05 at 7 30 13 am](https://cloud.githubusercontent.com/assets/781752/8005213/59cae130-0b55-11e5-86a8-cbebd3478c8a.png)
Old (active is not orange, client.coffee):
![old tabs screen shot](https://cloud.githubusercontent.com/assets/781752/7994797/4c8f78cc-0ade-11e5-9f9c-24de898f2015.png)

### Statusline ###
New:
![screen shot 2015-06-05 at 7 30 23 am](https://cloud.githubusercontent.com/assets/781752/8005219/613b51a2-0b55-11e5-9ea9-4374cad984c0.png)
Old:
![old statusline screen shot](https://cloud.githubusercontent.com/assets/781752/7994517/04183f72-0adc-11e5-9e86-bbde59d3604b.png)