### PR TITLE
Adding support for true color terminal inside neovim

### DIFF
--- a/colors/apprentice.vim
+++ b/colors/apprentice.vim
@@ -240,3 +240,24 @@ hi link diffNoEOL          WarningMsg
 hi link diffOnly           WarningMsg
 hi link diffRemoved        WarningMsg
 hi link diffAdded          String
+
+if $NVIM_TUI_ENABLE_TRUE_COLOR == 1
+  let g:terminal_foreground =  "#BCBCBC"
+  let g:terminal_background =  "#262626"
+  let g:terminal_color_0 =     "#1C1C1C"
+  let g:terminal_color_8 =     "#444444"
+  let g:terminal_color_1 =     "#AF5F5F"
+  let g:terminal_color_9 =     "#FF8700"
+  let g:terminal_color_2 =     "#5F875F"
+  let g:terminal_color_10 =    "#87AF87"
+  let g:terminal_color_3 =     "#87875F"
+  let g:terminal_color_11 =    "#FFFFAF"
+  let g:terminal_color_4 =     "#5F87AF"
+  let g:terminal_color_12 =    "#8FAFD7"
+  let g:terminal_color_5 =     "#5F5F87"
+  let g:terminal_color_13 =    "#8787AF"
+  let g:terminal_color_6 =     "#5F8787"
+  let g:terminal_color_14 =    "#5FAFAF"
+  let g:terminal_color_7 =     "#6C6C6C"
+  let g:terminal_color_15 =    "#FFFFFF"
+endif


### PR DESCRIPTION
This PR allows having the Apprentice colorscheme inside neovim term.

When neovim is in true color mode, it defaults to a standard ANSI palette for its terminal emulation, requiring terminal colors to be set manually. This PR adds the required colors.