### PR TITLE
Add note about terminal.sexy

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The table below contains a subset of Apprentice’s palette. You can use a color
 | 7                | `#6C6C6C` ![#6C6C6C](http://romainl.github.io/Apprentice/images/6c6c6c.png) | 15               | `#FFFFFF` ![#FFFFFF](http://romainl.github.io/Apprentice/images/ffffff.png) |
 | Foreground color | `#BCBCBC` ![#BCBCBC](http://romainl.github.io/Apprentice/images/bcbcbc.png) | Background color | `#262626` ![#262626](http://romainl.github.io/Apprentice/images/262626.png) |
 
-Here is a sample `~/.Xresources` for you Linux/BSD users:
+Here is a sample `~/.Xresources` for you Linux/BSD users. You can import this into [terminal.sexy](http://terminal.sexy) to convert it to the appropriate color scheme format for your preferred terminal emulator:
 
     *.foreground: #BCBCBC
     *.background: #262626


### PR DESCRIPTION
[http://terminal.sexy](http://terminal.sexy) has a convenient import/export feature to convert `.Xresources` formats to other terminal emulator color formats. This enables Apprentice shell theme to easily be used in most terminal emulators.