### PR TITLE
Better syntax highlighting for VimL

### DIFF
--- a/colors/apprentice.vim
+++ b/colors/apprentice.vim
@@ -283,6 +283,10 @@ let links = [
             \ ['diffOnly', 'WarningMsg'],
             \ ['diffRemoved', 'WarningMsg'],
             \ ['diffAdded', 'String'],
+            \ ['vimAutoCmdSfxList', 'Type'],
+            \ ['vimFunction', 'Function'],
+            \ ['vimIsCommand', 'Statement'],
+            \ ['vimUserFunc', 'Function'],
             \ ]
 augroup Apprentice
     autocmd!


### PR DESCRIPTION
A few miscellaneous links to make VimL highlighting a bit more consistent and colourful.