### PR TITLE
Greyscale completion menu

### DIFF
--- a/colors/apprentice.vim
+++ b/colors/apprentice.vim
@@ -63,9 +63,9 @@ if ($TERM =~ '256' || &t_Co >= 256) || has("gui_running")
   hi NonText          ctermbg=NONE ctermfg=240  guibg=NONE    guifg=#585858 cterm=NONE           gui=NONE
 
   hi Pmenu            ctermbg=238  ctermfg=250  guibg=#444444 guifg=#bcbcbc cterm=NONE           gui=NONE
-  hi PmenuSbar        ctermbg=240  ctermfg=NONE guibg=#585858 guifg=NONE    cterm=NONE           gui=NONE
-  hi PmenuSel         ctermbg=66   ctermfg=235  guibg=#5f8787 guifg=#262626 cterm=NONE           gui=NONE
-  hi PmenuThumb       ctermbg=66   ctermfg=66   guibg=#5f8787 guifg=#5f8787 cterm=NONE           gui=NONE
+  hi PmenuSbar        ctermbg=236  ctermfg=NONE guibg=#303030 guifg=NONE    cterm=NONE           gui=NONE
+  hi PmenuSel         ctermbg=240  ctermfg=250  guibg=#585858 guifg=#bcbcbc cterm=bold           gui=bold
+  hi PmenuThumb       ctermbg=240  ctermfg=66   guibg=#585858 guifg=#5f8787 cterm=NONE           gui=NONE
 
   hi ErrorMsg         ctermbg=131  ctermfg=235  guibg=#af5f5f guifg=#262626 cterm=NONE           gui=NONE
   hi ModeMsg          ctermbg=108  ctermfg=235  guibg=#87af87 guifg=#262626 cterm=NONE           gui=NONE


### PR DESCRIPTION
This pull request changes the colour of the selected item in the completion menu from a white foreground and a teal background to a simpler, greyscale setup: bold white foreground with medium grey background (note these colour names do not match up with the ones at the top of the file). Originally I made all the colours in the menu one shade darker, mimicking what completion menus often look like in GUI text editors. However, the background was the same as the cursorline, which was quite distracting (as the menu and the cursorline looked ‘connected’). So, the final version only changes the colour of the selected match, as well as both elements of the scroll bar to fit better.