### PR TITLE
Fix display in 8/16-color terminals

### DIFF
--- a/colors/apprentice.erb
+++ b/colors/apprentice.erb
@@ -64,12 +64,12 @@
     # If your colors are defined correctly, the resulting colorscheme is guaranteed
     # to work in GVim (Windows/Linux), MacVim (MacOS), and any properly set up terminal emulator.
     almost_black = ["#1c1c1c", 234, "black"]
-    darker_grey  = ["#262626", 235, "bg"]
+    darker_grey  = ["#262626", 235, "black"]
     dark_grey    = ["#303030", 236, "darkgrey"]
     grey         = ["#444444", 238, "darkgrey"]
     medium_grey  = ["#585858", 240, "darkgrey"]
     light_grey   = ["#6c6c6c", 242, "lightgrey"]
-    lighter_grey = ["#bcbcbc", 250, "fg"]
+    lighter_grey = ["#bcbcbc", 250, "lightgrey"]
     white        = ["#ffffff", 231, "white"]
     purple       = ["#5f5f87", 60, "darkmagenta"]
     light_purple = ["#8787af", 103, "magenta"]

--- a/colors/apprentice.vim
+++ b/colors/apprentice.vim
@@ -85,7 +85,7 @@ if ($TERM =~ '256' || &t_Co >= 256) || has("gui_running")
 elseif &t_Co == 8 || $TERM !~# '^linux' || &t_Co == 16
     set t_Co=16
 
-    hi Normal ctermbg=bg ctermfg=fg cterm=NONE
+    hi Normal ctermbg=black ctermfg=lightgrey cterm=NONE
 
     set background=dark
 
@@ -97,7 +97,7 @@ elseif &t_Co == 8 || $TERM !~# '^linux' || &t_Co == 16
     hi MatchParen ctermbg=black ctermfg=yellow cterm=NONE
     hi signColumn ctermbg=black ctermfg=lightgrey cterm=NONE
     hi Comment ctermbg=NONE ctermfg=darkgrey cterm=NONE
-    hi Conceal ctermbg=NONE ctermfg=fg cterm=NONE
+    hi Conceal ctermbg=NONE ctermfg=lightgrey cterm=NONE
     hi Constant ctermbg=NONE ctermfg=red cterm=NONE
     hi Error ctermbg=NONE ctermfg=darkred cterm=reverse
     hi Identifier ctermbg=NONE ctermfg=darkblue cterm=NONE
@@ -109,43 +109,43 @@ elseif &t_Co == 8 || $TERM !~# '^linux' || &t_Co == 16
     hi Todo ctermbg=NONE ctermfg=NONE cterm=reverse
     hi Type ctermbg=NONE ctermfg=magenta cterm=NONE
     hi Underlined ctermbg=NONE ctermfg=darkcyan cterm=underline
-    hi Pmenu ctermbg=darkgrey ctermfg=fg cterm=NONE
+    hi Pmenu ctermbg=darkgrey ctermfg=lightgrey cterm=NONE
     hi PmenuSbar ctermbg=darkgrey ctermfg=NONE cterm=NONE
-    hi PmenuSel ctermbg=darkcyan ctermfg=bg cterm=NONE
+    hi PmenuSel ctermbg=darkcyan ctermfg=black cterm=NONE
     hi PmenuThumb ctermbg=darkcyan ctermfg=darkcyan cterm=NONE
-    hi ErrorMsg ctermbg=darkred ctermfg=bg cterm=NONE
-    hi ModeMsg ctermbg=green ctermfg=bg cterm=NONE
+    hi ErrorMsg ctermbg=darkred ctermfg=black cterm=NONE
+    hi ModeMsg ctermbg=green ctermfg=black cterm=NONE
     hi MoreMsg ctermbg=NONE ctermfg=darkcyan cterm=NONE
     hi Question ctermbg=NONE ctermfg=green cterm=NONE
     hi WarningMsg ctermbg=NONE ctermfg=darkred cterm=NONE
     hi TabLine ctermbg=darkgrey ctermfg=darkyellow cterm=NONE
     hi TabLineFill ctermbg=darkgrey ctermfg=darkgrey cterm=NONE
-    hi TabLineSel ctermbg=darkyellow ctermfg=bg cterm=NONE
+    hi TabLineSel ctermbg=darkyellow ctermfg=black cterm=NONE
     hi ToolbarLine ctermbg=black ctermfg=NONE cterm=NONE
-    hi ToolbarButton ctermbg=darkgrey ctermfg=fg cterm=NONE
+    hi ToolbarButton ctermbg=darkgrey ctermfg=lightgrey cterm=NONE
     hi Cursor ctermbg=lightgrey ctermfg=NONE cterm=NONE
     hi CursorColumn ctermbg=darkgrey ctermfg=NONE cterm=NONE
     hi CursorLineNr ctermbg=darkgrey ctermfg=cyan cterm=NONE
     hi CursorLine ctermbg=darkgrey ctermfg=NONE cterm=NONE
     hi helpLeadBlank ctermbg=NONE ctermfg=NONE cterm=NONE
     hi helpNormal ctermbg=NONE ctermfg=NONE cterm=NONE
-    hi StatusLine ctermbg=darkyellow ctermfg=bg cterm=NONE
+    hi StatusLine ctermbg=darkyellow ctermfg=black cterm=NONE
     hi StatusLineNC ctermbg=darkgrey ctermfg=darkyellow cterm=NONE
-    hi StatusLineTerm ctermbg=darkyellow ctermfg=bg cterm=NONE
+    hi StatusLineTerm ctermbg=darkyellow ctermfg=black cterm=NONE
     hi StatusLineTermNC ctermbg=darkgrey ctermfg=darkyellow cterm=NONE
-    hi Visual ctermbg=bg ctermfg=blue cterm=reverse
+    hi Visual ctermbg=black ctermfg=blue cterm=reverse
     hi VisualNOS ctermbg=NONE ctermfg=NONE cterm=underline
     hi VertSplit ctermbg=darkgrey ctermfg=darkgrey cterm=NONE
-    hi WildMenu ctermbg=blue ctermfg=bg cterm=NONE
+    hi WildMenu ctermbg=blue ctermfg=black cterm=NONE
     hi Function ctermbg=NONE ctermfg=yellow cterm=NONE
     hi SpecialKey ctermbg=NONE ctermfg=darkgrey cterm=NONE
     hi Title ctermbg=NONE ctermfg=white cterm=NONE
-    hi DiffAdd ctermbg=bg ctermfg=green cterm=reverse
-    hi DiffChange ctermbg=bg ctermfg=magenta cterm=reverse
-    hi DiffDelete ctermbg=bg ctermfg=darkred cterm=reverse
-    hi DiffText ctermbg=bg ctermfg=red cterm=reverse
-    hi IncSearch ctermbg=darkred ctermfg=bg cterm=NONE
-    hi Search ctermbg=yellow ctermfg=bg cterm=NONE
+    hi DiffAdd ctermbg=black ctermfg=green cterm=reverse
+    hi DiffChange ctermbg=black ctermfg=magenta cterm=reverse
+    hi DiffDelete ctermbg=black ctermfg=darkred cterm=reverse
+    hi DiffText ctermbg=black ctermfg=red cterm=reverse
+    hi IncSearch ctermbg=darkred ctermfg=black cterm=NONE
+    hi Search ctermbg=yellow ctermfg=black cterm=NONE
     hi Directory ctermbg=NONE ctermfg=cyan cterm=NONE
     hi debugPC ctermbg=darkblue ctermfg=NONE cterm=NONE
     hi debugBreakpoint ctermbg=darkred ctermfg=NONE cterm=NONE


### PR DESCRIPTION
The current template file generates a colorscheme with the following
highlight for 8/16-color terminals:
``` vim
hi Normal ctermbg=bg ctermfg=fg cterm=NONE
```

When running Vim in a basic terminal (e.g., TERM=linux), this yields
E420, because bg and fg have no meaning prior to being defined by "hi
Normal."

This commit addresses the issue by replacing "bg" and "fg" in the
highlight definitions with "black" and "lightgrey," respectively.