### PR TITLE
Add arzg/apprentice-vscode to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ I removed it from `master` but you can still find it in the "fancylines-and-neov
 
 * [Apprentice-kitty](https://github.com/rsaihe/apprentice-kitty) is a port for kitty.
 
-* [Here](https://marketplace.visualstudio.com/items?itemName=amariampolskiy.theme-apprentice) is a port of Apprentice for Visual Studio Code.
+* [Here](https://marketplace.visualstudio.com/items?itemName=arzg.apprentice) and [here](https://marketplace.visualstudio.com/items?itemName=amariampolskiy.theme-apprentice) are ports of Apprentice for Visual Studio Code.
 
 * [Apprentice-windows-terminal](https://github.com/guilhermedeandrade/apprentice-windows-terminal) is a port for Windows Terminal.
 


### PR DESCRIPTION
I've made a [new port](https://marketplace.visualstudio.com/items?itemName=arzg.apprentice) to VS Code which I’ve tried to make as faithful to the original Apprentice as possible:

<img alt="apprentice-vscode" src="https://user-images.githubusercontent.com/31783266/169034101-ecf27280-9fd0-435f-ae28-326c4426eb1f.png">

I also went back to the original Sorcerer and replaced the Apprentice colour palette with Sorcerer’s (filling in a few missing colours where needed):

<img alt="apprentice-vscode-sorcerer" src="https://user-images.githubusercontent.com/31783266/169034266-445a51e1-5235-47cf-9607-b5459782581a.png">

Here’s that same code with the VS Code port currently listed in the readme:

<img alt="Screen Shot 2022-05-18 at 9 55 32 pm" src="https://user-images.githubusercontent.com/31783266/169034376-4d4c43a0-5c19-41bc-89b3-60445922fc5d.png">

I’ve made sure to test the theme with a variety of languages, making sure that each one is highlighted closely to how Vim highlights them (please ignore my nonsensical testing code):

<img alt="Screen Shot 2022-05-18 at 9 37 57 pm" src="https://user-images.githubusercontent.com/31783266/169034723-eeef851f-6eab-4317-a157-4841e0dde3e1.png">
